### PR TITLE
Fix README about setting i18n root scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can change the root scope if you will (this could be useful in libraries):
 
 ```ruby
 class MyGemPolicy < Tram::Policy
-  scope "mygem", "policies" # inherited by subclasses
+  root_scope "mygem", "policies" # inherited by subclasses
 end
 
 class Article::ReadinessPolicy < MyGemPolicy


### PR DESCRIPTION
Hi!

It seems, that actually we've got API to change `root_scope`, not `scope`. If I am not wrong, I think, it's not a bad idea to reflect this fact in README :) 