### PR TITLE
Fix be_invalid RSpec matcher if non-policy model is passed

### DIFF
--- a/lib/tram/policy/rspec.rb
+++ b/lib/tram/policy/rspec.rb
@@ -57,10 +57,12 @@ end
 
 RSpec::Matchers.define :be_invalid do
   match do |policy|
+    return expect(policy.valid?).to(be_falsey) unless policy.is_a?(Tram::Policy)
     expect(policy).to be_invalid_at
   end
 
   match_when_negated do |policy|
+    return expect(policy.valid?).to(be_truthy) unless policy.is_a?(Tram::Policy)
     expect(policy).not_to be_invalid_at
   end
 end

--- a/spec/tram/policy/rspec_spec.rb
+++ b/spec/tram/policy/rspec_spec.rb
@@ -46,4 +46,19 @@ RSpec.describe "RSpec support:" do
         .to raise_error RSpec::Expectations::ExpectationNotMetError
     end
   end
+
+  describe "to be_invalid" do
+    subject { double("model") }
+
+    it "fails with valid non-policy object" do
+      allow(subject).to receive(:valid?).and_return(true)
+      expect { expect(subject).to be_invalid }
+        .to raise_error RSpec::Expectations::ExpectationNotMetError
+    end
+
+    it "passes with invalid non-policy object" do
+      allow(subject).to receive(:valid?).and_return(false)
+      expect { expect(subject).to be_invalid }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Since this matcher overrides widely used in Rails default boolean matcher passing an AR model into it fails.