### PR TITLE
Add keywords to argument lists

### DIFF
--- a/lib/tram/policy.rb
+++ b/lib/tram/policy.rb
@@ -101,7 +101,7 @@ module Tram
 
     private
 
-    def initialize(*)
+    def initialize(*args, **kwargs)
       super
 
       self.class.validators.each do |validator|

--- a/lib/tram/policy.rb
+++ b/lib/tram/policy.rb
@@ -101,7 +101,7 @@ module Tram
 
     private
 
-    def initialize(*args, **kwargs)
+    def initialize(*, **)
       super
 
       self.class.validators.each do |validator|

--- a/lib/tram/policy/dsl.rb
+++ b/lib/tram/policy/dsl.rb
@@ -18,8 +18,8 @@ class Tram::Policy
     # @param  [Object] *args
     # @return [Tram::Policy]
     #
-    def [](*args)
-      new(*args)
+    def [](*args, **kwargs)
+      new(*args, **kwargs)
     end
 
     # Sets the root scope of the policy and its subclasses

--- a/lib/tram/policy/error.rb
+++ b/lib/tram/policy/error.rb
@@ -105,7 +105,7 @@ class Tram::Policy
       true
     end
 
-    def method_missing(name, *args, &block)
+    def method_missing(name, *args, **kwargs, &block)
       args.any? || block ? super : tags[name]
     end
   end

--- a/lib/tram/policy/error.rb
+++ b/lib/tram/policy/error.rb
@@ -106,7 +106,7 @@ class Tram::Policy
     end
 
     def method_missing(name, *args, **kwargs, &block)
-      args.any? || block ? super : tags[name]
+      args.any? || kwargs.any? || block ? super : tags[name]
     end
   end
 end

--- a/tram-policy.gemspec
+++ b/tram-policy.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |gem|
   gem.version  = "2.0.1"
   gem.author   = ["Viktor Sokolov (gzigzigzeo)", "Andrew Kozin (nepalez)"]
   gem.email    = "andrew.kozin@gmail.com"
-  gem.homepage = "https://github.com/tram/tram-policy"
+  gem.homepage = "https://github.com/tram-rb/tram-policy"
   gem.summary  = "Policy Object Pattern"
   gem.license  = "MIT"
 


### PR DESCRIPTION
Using `tram-policy` with 2.7.3 causes errors that look like this:

```
NoMethodError: undefined method `type' for nil:NilClass

    (eval) 6 __dry_initializer_initialize__(...)
    (eval):6:in `__dry_initializer_initialize__'

    [GEM_ROOT]/gems/tram-policy-2.0.1/lib/tram/policy.rb:105:in `initialize'
    [GEM_ROOT]/gems/tram-policy-2.0.1/lib/tram/policy/dsl.rb:22:in `new'
    [GEM_ROOT]/gems/tram-policy-2.0.1/lib/tram/policy/dsl.rb:22:in `[]' 
```

I assume this happens because `initialize` method uses `(*)` as an argument list and calls `super`, which is not working well with `dry-initializer`. Also there all methods accepting just `*args` should accept both `*args` and `**kwargs` as it is said here: https://bugs.ruby-lang.org/issues/16463.

I have added `**kwargs` to some argument lists and replaced `*` to `*args, **kwargs` in the `initialize` method, so it shouldn't break there.