### PR TITLE
Add support for ruby 3+

### DIFF
--- a/lib/tram/policy/dsl.rb
+++ b/lib/tram/policy/dsl.rb
@@ -9,7 +9,7 @@ class Tram::Policy
     # @return [self]
     #
     def validate(name = nil, **opts, &block)
-      local_validators << Validator.new(name, block, opts)
+      local_validators << Validator.new(name, block, **opts)
       self
     end
 

--- a/lib/tram/policy/error.rb
+++ b/lib/tram/policy/error.rb
@@ -41,7 +41,7 @@ class Tram::Policy
     # @return [String]
     #
     def message
-      key.is_a?(Symbol) ? I18n.t(*item) : key.to_s
+      key.is_a?(Symbol) ? I18n.t(key, **tags) : key.to_s
     end
 
     # Fetches an option

--- a/lib/tram/policy/errors.rb
+++ b/lib/tram/policy/errors.rb
@@ -47,7 +47,7 @@ class Tram::Policy
     #
     def filter(key = nil, **tags)
       list = each_with_object(Set.new) do |error, obj|
-        obj << error if error.contain?(key, tags)
+        obj << error if error.contain?(key, **tags)
       end
       self.class.new(scope: scope, errors: list)
     end
@@ -95,7 +95,7 @@ class Tram::Policy
       other.each do |err|
         key, opts = err.item
         opts = yield(opts) if block_given?
-        add key, opts.merge(options)
+        add key, **opts.merge(options)
       end
 
       self

--- a/lib/tram/policy/rspec.rb
+++ b/lib/tram/policy/rspec.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :be_invalid_at do |**tags|
   end
 
   def check(policy, tags)
-    @errors ||= policy.errors.filter(tags).map do |error|
+    @errors ||= policy.errors.filter(**tags).map do |error|
       { item: error.item }.tap do |obj|
         locales.each { |l| obj[l] = I18n.with_locale(l) { error.message } }
       end

--- a/spec/tram/policy/error_spec.rb
+++ b/spec/tram/policy/error_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Tram::Policy::Error do
-  subject(:error) { described_class.new :bad, options }
+  subject(:error) { described_class.new :bad, **options }
 
   let(:scope)   { %w[tram-policy] }
   let(:options) { { level: "warning", scope: scope } }


### PR DESCRIPTION
Hey, sorry for creating it without preliminary discussion, feel free to close this PR if I'm missing something.

Problem:

I've tried to use [evil-client](https://github.com/evilmartians/evil-client) with ruby 3.1.2 and found that it only supports ruby ~> 2.3. Then I cloned the repo to update ruby version, but rspec showed that its incompatible a bit. I started fixing errors and one of them lead me here. I run rspec in this gem with latest ruby and found these failures. 

Why it happens: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

P.S. I think this changes should work on pre-2.7 versions too, but honestly I only checked it on 3.1.2 